### PR TITLE
Attempted fix of #133

### DIFF
--- a/src/main/java/net/blay09/mods/excompressum/item/ItemCompressedHammer.java
+++ b/src/main/java/net/blay09/mods/excompressum/item/ItemCompressedHammer.java
@@ -52,7 +52,6 @@ public class ItemCompressedHammer extends ItemTool {
             for (ItemStack rewardStack : rewards) {
                 world.spawnEntityInWorld(new EntityItem(world, pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5, rewardStack));
             }
-            world.setBlockToAir(pos);
         }
         return super.onBlockDestroyed(itemStack, world, state, pos, entityLiving);
     }


### PR DESCRIPTION
The context for super is this block is a compressed block.  By setting it to air it changes the context without changing the functions called by super.  This causes a crash when XU goes to get the compression level on air.  I believe the actual block removal happens upstream by one of the super classes, so calling onBlockDestroyed should be sufficient.