### PR TITLE
improved heavy seive

### DIFF
--- a/src/main/java/net/blay09/mods/excompressum/block/BlockHeavySieve.java
+++ b/src/main/java/net/blay09/mods/excompressum/block/BlockHeavySieve.java
@@ -150,6 +150,17 @@ public class BlockHeavySieve extends BlockContainer {
 				}
 
 				if (tileEntity.addSiftable(player, heldItem)) {
+					int posX = (int) Math.ceil(pos.getX());
+					int posZ = (int) Math.ceil(pos.getZ());
+					for (int x = posX - 2; x <= posX + 2; x++) {
+						for (int z = posZ - 2; z <= posZ + 2; z++) {
+							BlockPos testPos = new BlockPos(x, pos.getY(), z);
+							TileHeavySieve otherEntity = (TileHeavySieve) world.getTileEntity(testPos);
+							if (otherEntity != null && !heldItem.isEmpty()) {
+								otherEntity.addSiftable(player, heldItem);
+							}
+						}
+					}
 					world.playSound(null, pos, SoundEvents.BLOCK_GRAVEL_STEP, SoundCategory.BLOCKS, 0.5f, 1f);
 					return true;
 				}
@@ -168,6 +179,17 @@ public class BlockHeavySieve extends BlockContainer {
 			if (ModConfig.automation.allowHeavySieveAutomation || !(player instanceof FakePlayer)) {
 				if (tileEntity.processContents(player)) {
 					world.playSound(null, pos, SoundEvents.BLOCK_SAND_STEP, SoundCategory.BLOCKS, 0.3f, 0.6f);
+				}
+				int posX = (int) Math.ceil(pos.getX());
+				int posZ = (int) Math.ceil(pos.getZ());
+				for (int x = posX - 2; x <= posX + 2; x++) {
+					for (int z = posZ - 2; z <= posZ + 2; z++) {
+						BlockPos testPos = new BlockPos(x, pos.getY(), z);
+						TileHeavySieve otherEntity = (TileHeavySieve) world.getTileEntity(testPos);
+						if (otherEntity != null  && !testPos.equals(pos)) {
+							otherEntity.processContents(player);
+						}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Previously the heavy sieve was somewhat obsolete due to the ability to use the regular sieve in a 5x5 grid, this meant that the rate of sieving was higher without the use of the heavy sieve.

regular: 5x5x1 = 25 blocks per sieve
heavy: 1x1x9 = 9 blocks per sieve

I have resolved this by allowing the use of an array of heavy sieves.

After:
regular: 5x5x1 = 25 blocks per sieve
heavy: 5x5x9 = 225 blocks per sieve

[Here is a demonstration.](https://imgur.com/a/PbQ3d)

Finally I manually removed all of the formatting my IDE entered to get rid of the wall of green and red :)