### PR TITLE
Improved finding first empty slot for some tile entities

### DIFF
--- a/src/main/java/net/blay09/mods/excompressum/tile/AutoCompressorTileEntity.java
+++ b/src/main/java/net/blay09/mods/excompressum/tile/AutoCompressorTileEntity.java
@@ -180,9 +180,8 @@ public class AutoCompressorTileEntity extends BaseTileEntity implements ITickabl
         for (int i = 0; i < outputSlots.getSlots(); i++) {
             ItemStack slotStack = outputSlots.getStackInSlot(i);
             if (slotStack.isEmpty()) {
-                if (firstEmptySlot == -1) {
-                    firstEmptySlot = i;
-                }
+                firstEmptySlot = i;
+                break;
             } else {
                 if (slotStack.getCount() + itemStack.getCount() <= slotStack.getMaxStackSize() && isItemEqualWildcard(slotStack, itemStack)) {
                     slotStack.grow(itemStack.getCount());

--- a/src/main/java/net/blay09/mods/excompressum/tile/AutoHammerTileEntity.java
+++ b/src/main/java/net/blay09/mods/excompressum/tile/AutoHammerTileEntity.java
@@ -222,9 +222,8 @@ public class AutoHammerTileEntity extends BaseTileEntity implements ITickableTil
         for (int i = 0; i < outputSlots.getSlots(); i++) {
             ItemStack slotStack = outputSlots.getStackInSlot(i);
             if (slotStack.isEmpty()) {
-                if (firstEmptySlot == -1) {
-                    firstEmptySlot = i;
-                }
+                firstEmptySlot = i;
+                break;
             } else {
                 if (slotStack.getCount() + itemStack.getCount() <= slotStack.getMaxStackSize() && slotStack.isItemEqual(itemStack) && ItemStack.areItemStackTagsEqual(slotStack, itemStack)) {
                     slotStack.grow(itemStack.getCount());

--- a/src/main/java/net/blay09/mods/excompressum/tile/AutoSieveTileEntityBase.java
+++ b/src/main/java/net/blay09/mods/excompressum/tile/AutoSieveTileEntityBase.java
@@ -213,9 +213,8 @@ public abstract class AutoSieveTileEntityBase extends BaseTileEntity implements 
         for (int i = 0; i < outputSlots.getSlots(); i++) {
             ItemStack slotStack = outputSlots.getStackInSlot(i);
             if (slotStack.isEmpty()) {
-                if (firstEmptySlot == -1) {
-                    firstEmptySlot = i;
-                }
+                firstEmptySlot = i;
+                break;
             } else {
                 if (slotStack.getCount() + itemStack.getCount() <= slotStack.getMaxStackSize() && slotStack.isItemEqual(itemStack) && ItemStack.areItemStackTagsEqual(slotStack, itemStack)) {
                     slotStack.grow(itemStack.getCount());


### PR DESCRIPTION
This should speed up finding the first empty slot in a tile entities inventory.

Correct me if this code was intentional but in the current way, it will use the last empty slot if all output slots are empty because you do not break the for-loop. It will just overwrite it again and again if it finds no valid stack to merge it before.

So if you have completely empty output slots or only some output slots filled with items which the current stack can't be merged to, the loop will give you the last empty slot, not the first one which is inefficient.
This also removes the check if `emptySlot` is `-1` because it's redundant as this will always be the case when you break the loop.